### PR TITLE
typo: kaggle user name

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc && ncc build dist/index.js -o dist",
-    "local-run": "INPUT_USER_NAME=spshota node dist/index.js",
+    "local-run": "INPUT_USER_NAME=spidermandance node dist/index.js",
     "test": "jest",
     "prepare": "yarn tsc"
   },


### PR DESCRIPTION
I  modified the environment variable values passed when running the job locally as follows

Before: spshota
After: spidermandance

This will cause the following command to be executed when the yarn local-run command is run

```shell
INPUT_USER_NAME=spidermandance node dist/index.js
```
